### PR TITLE
follow sql type update

### DIFF
--- a/sqlparser/analyzer.go
+++ b/sqlparser/analyzer.go
@@ -96,9 +96,9 @@ func AsInterface(node ValExpr) (interface{}, error) {
 	case ListArg:
 		return string(node), nil
 	case StrVal:
-		return sqltypes.MakeString(node), nil
+		return sqltypes.NewVarBinary(string(node)), nil
 	case NumVal:
-		n, err := sqltypes.BuildIntegral(string(node))
+		n, err := sqltypes.NewIntegral(string(node))
 		if err != nil {
 			return nil, fmt.Errorf("type mismatch: %s", err)
 		}

--- a/sqlparser/ast.go
+++ b/sqlparser/ast.go
@@ -620,7 +620,7 @@ func (*CaseExpr) IValExpr()   {}
 type StrVal []byte
 
 func (node StrVal) Format(buf *TrackedBuffer) {
-	s := sqltypes.MakeString([]byte(node))
+	s := sqltypes.NewVarBinary(string(node))
 	s.EncodeSQL(buf)
 }
 

--- a/sqlparser/parsed_query.go
+++ b/sqlparser/parsed_query.go
@@ -90,7 +90,7 @@ func EncodeValue(buf *bytes.Buffer, value interface{}) error {
 			return err
 		}
 	default:
-		v, err := sqltypes.BuildValue(bindVal)
+		v, err := sqltypes.InterfaceToValue(bindVal)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
https://github.com/youtube/vitess/pull/3018
sqltypeのインターフェースが変更されてる。つらぽよ。

よくわからないけど以下参考にしてみた。
- [MakeString -> NewVarBinary]( https://github.com/youtube/vitess/pull/3018/commits/0d75784cbde1c74c5360114921743a9ad754faa2)
- [BuildIntegral -> NewIntegral](https://github.com/youtube/vitess/blob/4ad01c5d0225b42a50945301173089afc09d5b22/go/sqltypes/value_test.go#L243-L246)
- [BuildValue ->  InterfaceToValue](https://github.com/youtube/vitess/blob/4ad01c5d0225b42a50945301173089afc09d5b22/go/sqltypes/value_test.go#L294-L298)
